### PR TITLE
IP and email scoring bot

### DIFF
--- a/sopel/modules/emailcheck.py
+++ b/sopel/modules/emailcheck.py
@@ -1,0 +1,282 @@
+# coding=utf-8
+"""
+emailcheck.py - Watch oper messages for new nicks being registered
+Copyright © 2021, Kufat <kufat@kufat.net>
+Based on existing sopel code.
+Licensed under the Eiffel Forum License 2.
+"""
+
+import logging
+import re
+import urllib
+
+import sqlalchemy.sql
+
+from dataclasses import dataclass
+
+from sopel import db, module
+from sopel.config.types import FilenameAttribute, StaticSection, ValidatedAttribute, ListAttribute
+from sopel.tools import events, target, Identifier
+
+from sqlalchemy import Column, String, Float, Boolean, TIMESTAMP
+from sqlalchemy.ext.declarative import declarative_base
+
+try:
+    from ip import get_exemption
+except:
+    def get_exemption(ip):
+        return "Can't access exemptions; failing safe"
+
+EMAIL_REGEX = re.compile(r"([a-zA-Z0-9_.+-]+)@([a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)")
+IRCCLOUD_USER_REGEX = re.compile(r"[us]id[\d]{4,}")
+DOMAIN_LEN = 50
+
+DEFAULT_EXEMPT_SUFFIXES = {
+    "@gmail.com",
+    "@hotmail.com",
+    "@protonmail.com",
+    ".edu"
+}
+
+KILL_STR = ":Use of disposable email service for nick registration"
+
+LOGGER = logging.getLogger(__name__)
+
+BASE = declarative_base()
+
+#SQLAlchemy container class
+class KnownEmails(BASE):
+    __tablename__ = 'known_emails'
+    domain = Column(String(DOMAIN_LEN), primary_key=True)
+    first_nick = Column(String(40))
+    score = Column(Float)
+    flag_disposable = Column(Boolean)
+    flag_recent_abuse = Column(Boolean)
+    first_seen = Column(TIMESTAMP, server_default=sqlalchemy.sql.func.now())
+
+class EmailCheckSection(StaticSection):
+    IPQS_key = ValidatedAttribute('IPQS_key')
+    disallow_threshold = ValidatedAttribute("disallow_threshold", parse=float)
+    malicious_threshold = ValidatedAttribute("malicious_threshold", parse=float)
+    gline_time = ValidatedAttribute('gline_time')
+    #TODO; just hard-coded ones for now
+    exempt_suffixes = ListAttribute("exempt_suffixes")
+    warn_chans = ListAttribute("warn_chans")
+    protect_chans = ListAttribute("protect_chans")
+
+def configure(config):
+    config.define_section('emailcheck', EmailCheckSection)
+    config.emailcheck.configure_setting('IPQS_key',
+                                        'Access key for IPQS service')
+    config.emailcheck.configure_setting('disallow_threshold',
+                                        'Addresses with scores >= this will be disallowed; no punishment',
+                                        default=50.0)
+    config.emailcheck.configure_setting('malicious_threshold',
+                                        'Addresses with scores >= this will be interpreted as attacks',
+                                        default=75.0)
+    config.emailcheck.configure_setting('gline_time',
+                                        'Users attempting to register with malicious addresses will be '
+                                        'glined for this priod of time.',
+                                        default="24h")
+    config.emailcheck.configure_setting('exempt_suffixes',
+                                        'Suffixes (TLD, whole domain, etc.) to exempt from checking')
+    config.emailcheck.configure_setting('warn_chans',
+                                        'List of channels to warn when a suspicious user is detected. '
+                                        'May be empty.')
+    config.emailcheck.configure_setting('protect_chans',
+                                        'List of channels to +R after malicious attempt to reg. '
+                                        'May be empty.')
+
+def setup(bot):
+    bot.config.define_section('emailcheck', EmailCheckSection)
+
+@dataclass
+class Email:
+    user: str
+    domain: str
+    def get_address(self):
+        return f'{self.user}@{self.domain}'
+    def __str__(self):
+        return self.get_address()
+    def __post_init__(self):
+        self.domain = self.domain.lower()
+
+@dataclass
+class DomainInfo:
+    score: float
+    flag_disposable: bool
+    flag_recent_abuse: bool
+
+def alert(bot, alert_msg: str, log_err: bool = False):
+    for channel in config.emailcheck.warn_chans:
+        bot.say(alert_msg, channel)
+    if log_err:
+        LOGGER.error(alert_msg)
+
+def add_badmail(bot, email):
+    #Right now we're BADMAILing whole domains. This might change.
+    bot.write("NICKSERV", "badmail", "add", f'*@{email.domain}')
+
+def fdrop(bot, nick: str):
+    bot.write("NICKSERV", "fdrop", nick.lower())
+
+def gline_ip(bot, ip: str, duration: str):
+    bot.write("GLINE", f'*@{ip}', duration, KILL_STR)
+
+def gline_username(bot, nick: str, duration: str):
+    if known_user := bot.users.get(Identifier(nick)):
+        username = known_user.user.lower() # Should already be lowercase
+        if IRCCLOUD_USER_REGEX.match(username):
+            bot.write("GLINE", f'{username}@*', duration, KILL_STR)
+            return
+        else:
+            alert(bot, f"User {nick} had unexpected non-IRCCloud username {username}", true)
+    else:
+        alert(bot, f"Couldn't find irccloud uid/sid for {nick} to G-line!", true)
+    kill_nick(bot, nick) # Something went wrong with G-line, so fall back to /kill
+
+def kill_nick(bot, nick: str):
+    bot.write("KILL", nick.lower(), KILL_STR)
+
+def gline_strategy(bot, nick):
+    if (known_user := bot.users.get(Identifier(nick))):
+        if hasattr(known_user, "ip"):
+            ip = known_user.ip
+            exemption = get_exemption(ip)
+            if exemption:
+                if "irccloud" in exemption.lower():
+                    # IRCCloud special case: ban uid/sid
+                    return ["gline_username", known_user.user]
+                else: # Fully exempt, so no g-line
+                    return None
+            else: # No exemption
+                return ["gline_ip", ip]
+    else: # Fail safely
+        return None
+
+def gline_or_kill(bot, nick: str, duration: str):
+    if strategy := gline_strategy(bot, nick):
+        if strategy[0] == "gline_ip":
+            gline_ip(bot, strategy[1], duration)
+        elif strategy[0] == "gline_username":
+            gline_username(bot, strategy[1], duration)
+        else:
+            alert(bot, f"Unknown strategy {strategy} for nick {nick}", true)
+            kill_nick(bot, nick) # safest option
+    else:
+        kill_nick(bot, nick) # duration ignored
+
+def protect_chans(bot):
+    for chan in config.emailcheck.protect_chans:
+        bot.write("MODE", chan, "+R")
+
+def malicious_response(bot, nick: str, email):
+    fdrop(bot, nick)
+    add_badmail(bot, email)
+    say(f"You have been temporarily banned from this network because {email.domain} "
+        "has a history of spam or abuse, and/or is a disposable email domain. "
+        "If this is a legitimate domain, contact staff for assistance.",
+        nick.lower())
+    gline_or_kill(bot, nick, config.emailcheck.gline_time)
+    protect_chans(bot)
+    alert(bot, f"ALERT: User {nick} attempted to register a nick with disposable/spam domain {email.domain}!")
+
+def disallow_response(bot, nick: str, email):
+    fdrop(bot, nick)
+    add_badmail(bot, email)
+    say(f"Your registration has been disallowed because {email.domain} appears to be suspicious. "
+        "If this is a legitimate domain, contact staff for assistance.",
+        nick.lower())
+    alert(bot, f"WARNING: User {nick} attempted to register a nick with suspicious domain {email.domain}.")
+
+def fetch_IPQS_email_score(
+    email_addr: str,
+    key: str,
+    fast: bool = True
+    ) -> tuple[float, bool, bool]: #score, disposable, has recent abuse flag set
+    '''Perform lookup on a specific email adress using ipqualityscore.com'''
+    email_str = urllib.parse.quote(email_addr)
+    faststr = str(bool(fast)).lower() #lower + handle None and other garbage
+    params = urllib.parse.urlencode({'fast': faststr})
+    with urllib.request.urlopen(
+        f"https://ipqualityscore.com/api/json/email/{key}/{email_str}?{params}") as url:
+            data = json.loads(url.read().decode())
+            LOGGER.debug(data)
+    if not data['success']:
+        errstr = f"{email_addr} lookup failed with {data['message']}"
+        LOGGER.error(errstr)
+        raise RuntimeError(errstr)
+    return (data['fraud_score'], data["disposable"], data["recent_abuse"])
+
+def get_email_score_from_db(session, email):
+    query_result = session.query(KnownEmails)\
+        .filter(KnownEmails.domain == email.domain)\
+        .one_or_none()
+    if query_result:
+        #Any known problematic provider should've been BADMAILed by now, but...
+        return DomainInfo(query_result.score,
+                          query_result.flag_disposable,
+                          query_result.flag_recent_abuse)
+
+def store_email_score_in_db(session, email, nick, IPQSresult):
+    new_known_email = KnownEmails(domain= email.doman[:DOMAIN_LEN],
+                                    first_nick= nick,
+                                    score= IPQSresult[0],
+                                    flag_disposable= IPQSresult[1],
+                                    flag_recent_abuse= IPQSresult[2])
+    session.add(new_known_email)
+    session.commit()
+
+def retrieve_score(bot, email, nick):
+    session = bot.db.ssession()
+    try:
+        if retval := get_email_score_from_db(session, email):
+            return retval
+        else:
+            if IPQSresult := fetch_IPQS_email_score(email, config.emailcheck.IPQS_key):
+                store_email_score_in_db(session, email, nick, IPQSresult)
+                return IPQSresult
+            else: #Shouldn't be possible
+                raise RuntimeError("Couldn't retrieve IPQS!")
+    except SQLAlchemyError:
+        session.rollback()
+        raise
+    finally:
+        session.remove()
+
+def check_email(bot, email, nick):
+    if any(map(email.endswith, DEFAULT_EXEMPT_SUFFIXES)):
+        #email is exempt
+        LOGGER.info(f'Email {email} used by {nick} is on the exemption list.')
+        return None # No lookup, no result
+    #Check database
+    else:
+        return retrieve_score(bot, email, nick)
+
+# <NickServ> ExampleAccount REGISTER: ExampleNick to foo@example.com
+# (note the 0x02 bold chars)
+@module.rule(r'(\S*)\s*REGISTER: ?([\S]+?)? to ?(\S+)@(\S+?)?$')
+@module.event("PRIVMSG")
+@module.priority("high")
+def handle_ns_register(bot, trigger):
+    if "nickserv" != trigger.sender.lower():
+        LOGGER.warning(f"Fake registration notice from {trigger.sender.lower()}!")
+        return
+    #It's really from nickserv.
+    _, nick, email_user, email_domain = trigger.groups()
+    email = Email(email_user, email_domain)
+    try:
+        if res := check_email(bot, email_user, email_domain, nick): #may be None, in which case we're done
+            if res.flag_disposable or (
+                res.score >= config.emailcheck.malicious_threshold):
+                malicious_response(bot, nick, email)
+            elif res.flag_recent_abuse or (
+                res.score >= config.emailcheck.disallow_threshold):
+                disallow_response(bot, nick, email)
+            else:
+                #already logged server response
+                return LOGGER.debug(f'Registration of {nick} to {email} OK.')
+    except:
+        alert(f"Lookup for f{nick} with email @f{domain} failed! Keep an eye on them.")
+
+

--- a/sopel/modules/emailcheck.py
+++ b/sopel/modules/emailcheck.py
@@ -178,10 +178,11 @@ def protect_chans(bot):
 def malicious_response(bot, nick: str, email):
     fdrop(bot, nick)
     add_badmail(bot, email)
-    bot.say(f"You have been temporarily banned from this network because {email.domain} "
-             "has a history of spam or abuse, and/or is a disposable email domain. "
-             "If this is a legitimate domain, contact staff for assistance.",
-             nick.lower())
+    if not email_safe_mode:
+        bot.say(f"You have been temporarily banned from this network because {email.domain} "
+                "has a history of spam or abuse, and/or is a disposable email domain. "
+                "If this is a legitimate domain, contact staff for assistance.",
+                nick.lower())
     gline_or_kill(bot, nick, bot.config.emailcheck.gline_time)
     protect_chans(bot)
     alert(bot, f"ALERT: User {nick} attempted to register a nick with disposable/spam domain {email.domain}!")
@@ -189,9 +190,10 @@ def malicious_response(bot, nick: str, email):
 def disallow_response(bot, nick: str, email):
     fdrop(bot, nick)
     add_badmail(bot, email)
-    bot.say(f"Your registration has been disallowed because {email.domain} appears to be suspicious. "
-             "If this is a legitimate domain, contact staff for assistance.",
-             nick.lower())
+    if not email_safe_mode:
+        bot.say(f"Your registration has been disallowed because {email.domain} appears to be suspicious. "
+                "If this is a legitimate domain, contact staff for assistance.",
+                nick.lower())
     alert(bot, f"WARNING: User {nick} attempted to register a nick with suspicious domain {email.domain}.")
 
 def fetch_validator_pizza_email_info(email_addr: str ) \

--- a/sopel/modules/emailcheck.py
+++ b/sopel/modules/emailcheck.py
@@ -173,10 +173,10 @@ def protect_chans(bot):
 def malicious_response(bot, nick: str, email):
     fdrop(bot, nick)
     add_badmail(bot, email)
-    say(f"You have been temporarily banned from this network because {email.domain} "
-        "has a history of spam or abuse, and/or is a disposable email domain. "
-        "If this is a legitimate domain, contact staff for assistance.",
-        nick.lower())
+    bot.say(f"You have been temporarily banned from this network because {email.domain} "
+             "has a history of spam or abuse, and/or is a disposable email domain. "
+             "If this is a legitimate domain, contact staff for assistance.",
+             nick.lower())
     gline_or_kill(bot, nick, config.emailcheck.gline_time)
     protect_chans(bot)
     alert(bot, f"ALERT: User {nick} attempted to register a nick with disposable/spam domain {email.domain}!")
@@ -184,9 +184,9 @@ def malicious_response(bot, nick: str, email):
 def disallow_response(bot, nick: str, email):
     fdrop(bot, nick)
     add_badmail(bot, email)
-    say(f"Your registration has been disallowed because {email.domain} appears to be suspicious. "
-        "If this is a legitimate domain, contact staff for assistance.",
-        nick.lower())
+    bot.say(f"Your registration has been disallowed because {email.domain} appears to be suspicious. "
+             "If this is a legitimate domain, contact staff for assistance.",
+             nick.lower())
     alert(bot, f"WARNING: User {nick} attempted to register a nick with suspicious domain {email.domain}.")
 
 def fetch_IPQS_email_score(
@@ -255,7 +255,7 @@ def check_email(bot, email, nick):
 
 # <NickServ> ExampleAccount REGISTER: ExampleNick to foo@example.com
 # (note the 0x02 bold chars)
-@module.rule(r'(\S*)\s*REGISTER: ?([\S]+?)? to ?(\S+)@(\S+?)?$')
+@module.rule(r'(\S*)\s*REGISTER: \u0002?([\S]+?)\u0002? to \u0002?(\S+)@(\S+?)\u0002?$')
 @module.event("PRIVMSG")
 @module.priority("high")
 def handle_ns_register(bot, trigger):

--- a/sopel/modules/emailcheck.py
+++ b/sopel/modules/emailcheck.py
@@ -284,7 +284,7 @@ def check_email(bot, email, nick):
 def toggle_safe(bot, trigger):
     global safe_mode
     safe_mode = not safe_mode
-    return bot.reply(f"Email check module safe mode now {'on' if safe_mode else 'off'}")
+    return bot.reply(f"Email check module safe mode now {'ON' if safe_mode else 'OFF'}")
 
 # <NickServ> ExampleAccount REGISTER: ExampleNick to foo@example.com
 # (note the 0x02 bold chars)
@@ -311,4 +311,3 @@ def handle_ns_register(bot, trigger):
                 return LOGGER.debug(f'Registration of {nick} to {email} OK.')
     except:
         alert(f"Lookup for f{nick} with email @f{domain} failed! Keep an eye on them.")
-

--- a/sopel/modules/emailcheck.py
+++ b/sopel/modules/emailcheck.py
@@ -90,8 +90,8 @@ class Email:
 
 @dataclass
 class DomainInfo:
-    flag_disposable: bool
     flag_valid: bool
+    flag_disposable: bool
 
 def alert(bot, alert_msg: str, log_err: bool = False):
     for channel in bot.config.emailcheck.warn_chans:
@@ -218,7 +218,7 @@ def fetch_validator_pizza_email_info(email_addr: str ) \
         return ValidatorPizzaResponse(data['mx'], data["disposable"])
     elif data['status'] == HTTPStatus.BAD_REQUEST:
         # Address is invalid, assume typo
-        return (False, None)
+        return ValidatorPizzaResponse(False, None)
     elif data['status'] == HTTPStatus.TOO_MANY_REQUESTS:
         # This is unlikely enough that I'm going to postpone dealing with it
         raise RuntimeError("Hit request limit!")

--- a/sopel/modules/emailcheck.py
+++ b/sopel/modules/emailcheck.py
@@ -28,7 +28,7 @@ except:
         return "Can't access exemptions; failing safe"
 
 EMAIL_REGEX = re.compile(r"([a-zA-Z0-9_.+-]+)@([a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)")
-IRCCLOUD_USER_REGEX = re.compile(r"[us]id[\d]{4,}")
+IRCCLOUD_USER_REGEX = re.compile(r"[us]id[0-9]{4,}")
 DOMAIN_LEN = 50
 
 DEFAULT_EXEMPT_SUFFIXES = {
@@ -237,7 +237,7 @@ def retrieve_score(bot, email, nick):
                 store_email_score_in_db(session, email, nick, IPQSresult)
                 return IPQSresult
             else: #Shouldn't be possible
-                raise RuntimeError("Couldn't retrieve IPQS!")
+                raise RuntimeError(f"Couldn't retrieve IPQS for {email}!")
     except SQLAlchemyError:
         session.rollback()
         raise
@@ -278,5 +278,4 @@ def handle_ns_register(bot, trigger):
                 return LOGGER.debug(f'Registration of {nick} to {email} OK.')
     except:
         alert(f"Lookup for f{nick} with email @f{domain} failed! Keep an eye on them.")
-
 

--- a/sopel/modules/emailcheck.py
+++ b/sopel/modules/emailcheck.py
@@ -88,11 +88,6 @@ class Email:
     def __post_init__(self):
         self.domain = self.domain.lower()
 
-@dataclass
-class DomainInfo:
-    flag_valid: bool
-    flag_disposable: bool
-
 def alert(bot, alert_msg: str, log_err: bool = False):
     for channel in bot.config.emailcheck.warn_chans:
         bot.say(alert_msg, channel)
@@ -235,14 +230,14 @@ def get_email_info_from_db(session, email):
         .one_or_none()
     if query_result:
         #Any known problematic provider should've been BADMAILed by now, but...
-        return DomainInfo(query_result.flag_valid,
-                          query_result.flag_disposable)
+        return ValidatorPizzaResponse(flag_valid=query_result.flag_valid,
+                                      flag_disposable=query_result.flag_disposable)
 
 def store_email_info_in_db(session, email, nick, result):
-    new_known_email = KnownEmails(domain= email.domain[:DOMAIN_LEN],
-                                  first_nick= nick,
-                                  flag_valid= result.flag_valid,
-                                  flag_disposable= result.flag_disposable)
+    new_known_email = KnownEmails(domain=email.domain[:DOMAIN_LEN],
+                                  first_nick=nick,
+                                  flag_valid=result.flag_valid,
+                                  flag_disposable=result.flag_disposable)
     session.add(new_known_email)
 
 def retrieve_info_for_email(bot, email, nick):

--- a/sopel/modules/ip.py
+++ b/sopel/modules/ip.py
@@ -10,52 +10,227 @@ https://sopel.chat
 
 from __future__ import unicode_literals, absolute_import, print_function, division
 
+import ipaddress
 import logging
 import os
 import socket
 import tarfile
+import typing
 
 import geoip2.database
+import re
+import urllib.request, json
 
-from sopel.config.types import FilenameAttribute, StaticSection
-from sopel.module import commands, example
-from sopel.tools import web
+import sqlalchemy.sql
 
-urlretrieve = None
-try:
-    from urllib import urlretrieve
-except ImportError:
-    try:
-        # urlretrieve has been put under urllib.request in Python 3.
-        # It's also deprecated so this should probably be replaced with
-        # urllib2.
-        from urllib.request import urlretrieve
-    except ImportError:
-        pass
+from random import randint
+from urllib.request import urlretrieve
 
+#from minfraud import Client
+
+from sopel import module
+from sopel.config.types import FilenameAttribute, StaticSection, ValidatedAttribute, ListAttribute
+from sopel.tools import web, events, target, Identifier
+
+from sqlalchemy import Column, Integer, String, Float, Boolean, TIMESTAMP, Text
+from sqlalchemy.ext.declarative import declarative_base
+
+IRCCLOUD_IP = [
+    "2001:67c:2f08::/48",
+    "2a03:5180:f::/64",
+    "5.254.36.56/29",
+    "192.184.8.73",
+    "192.184.8.103",
+    "192.184.9.108",
+    "192.184.9.110",
+    "192.184.9.112",
+    "192.184.10.9",
+    "192.184.10.118",
+    ]
+
+IRCCLOUD_REASON = "IRCCloud"
+
+MIBBIT_IP = [
+    "207.192.75.252",
+    "64.62.228.82",
+    "78.129.202.38",
+    "109.169.29.95"
+    ]
+
+MIBBIT_REASON = "Mibbit"
+
+#Hardcoded for safety
+EXEMPT_IP = [
+    ("104.248.43.234", "Lazar, DigitalOcean"),
+    ("13.59.180.136", "War_ Limnoria bot"),
+    ("138.68.23.34", "Approved bot (Idlebot, aismallard)"),
+    ("18.132.171.104", "TARS"),
+    ("3.136.223.150", "bluesoul"),
+    ("54.174.11.206", "Helen"),
+    ("69.115.75.7", "Kufat and bots"),
+    ("94.159.196.226", "docazra, longtime user, IP is on dnsbl"),
+    ("2604:a880:2:d0::250:9001", "Approved bot (Idlebot, aismallard)"),
+    ("91.132.86.177", "bluesoul's bouncer"),
+    ("2001:470:1f07:13b::/64", "kufat's tunnelbroker"),
+    ]
 
 LOGGER = logging.getLogger(__name__)
+who_reqs = {}  # Keeps track of reqs coming from this plugin, rather than others
 
+# This dict will mostly be used as a list (walking each element) but having it as a dict
+# is useful for preventing duplicate entries.
+exemptions = {ipaddress.ip_network(i):reason for i, reason in EXEMPT_IP}
+exemptions.update(( (ipaddress.ip_network(i), IRCCLOUD_REASON) for i in IRCCLOUD_IP))
+exemptions.update(( (ipaddress.ip_network(i), MIBBIT_REASON) for i in MIBBIT_IP))
+
+BASE = declarative_base()
+
+# This table will only receive inserts, not updates.
+class KnownIPs(BASE):
+    __tablename__ = 'known_ips'
+    ip = Column(String(50), primary_key=True, unique=True, index=True)
+    score = Column(Float)
+    flag_recent_abuse = Column(Boolean)
+    flag_is_proxy = Column(Boolean)
+    insert_time = Column(TIMESTAMP, server_default=sqlalchemy.sql.func.now())
+
+class ExemptIPs(BASE):
+    __tablename__ = 'exempt_ips'
+    ip = Column(String(50), primary_key=True, unique=True, index=True)
+    # Define type of exemption.
+    # GLine username e.g. uid123@* if true, no g-line at all if false. For IRCCloud.
+    gline_username = Column(Boolean)
+    exempt_reason = Column(Text)
+
+# Existing rows in this table will be updated when a user is seen
+# from the same nick/IP combination.
+# TODO Deferred feature.
+class KnownUsers(BASE):
+    __tablename__ = 'known_users'
+    nick = Column(String(40), primary_key=True)
+    ip = Column(String(50), primary_key=True)
+    cloaked_host = Column(String(40))
+    last_seen = Column(TIMESTAMP, server_default=sqlalchemy.sql.func.now())
 
 class GeoipSection(StaticSection):
     GeoIP_db_path = FilenameAttribute('GeoIP_db_path', directory=True)
     """Path of the directory containing the GeoIP database files."""
-
+    IPQS_key = ValidatedAttribute('IPQS_key')
+    warn_threshold = ValidatedAttribute('warn_threshold', parse=float)
+    malicious_threshold = ValidatedAttribute('malicious_threshold', parse=float)
+    warn_chans = ListAttribute("warn_chans")
+    protect_chans = ListAttribute("protect_chans")
 
 def configure(config):
-    """
-    | name | example | purpose |
-    | ---- | ------- | ------- |
-    | GeoIP\\_db\\_path | /home/sopel/GeoIP/ | Path to the GeoIP database files |
-    """
     config.define_section('ip', GeoipSection)
     config.ip.configure_setting('GeoIP_db_path',
                                 'Path of the GeoIP db files')
+    config.ip.configure_setting('IPQS_key',
+                                'Access key for IPQS service')
+    config.ip.configure_setting('warn_threshold',
+                                'Addresses with scores >= this will generate an alert',
+                                default=50.0)
+    config.ip.configure_setting('malicious_threshold',
+                                'Addresses with scores >= this will be z-lined',
+                                default=70.0)
+    config.ip.configure_setting('warn_chans',
+                                'List of channels to warn when a suspicious user is detected. '
+                                'May be empty.')
+    config.ip.configure_setting('protect_chans',
+                                'List of channels to +R after malicious attempt to reg. '
+                                'May be empty.')
 
 
 def setup(bot):
     bot.config.define_section('ip', GeoipSection)
 
+def alert(bot, alert_msg: str, log_err = False):
+    for channel in config.ip.warn_chans:
+        bot.say(alert_msg, channel)
+    if log_err:
+        LOGGER.error(alert_msg)
+
+def get_exemption(host):
+    if isinstance(host, ip.IPv4Address) or isinstance(host, ip.IPv6Address):
+        host = ip
+    else:
+        try:
+            ip = ipaddress.ip_address(socket.getaddrinfo(host, None)[0][4][0])
+        except:
+            raise
+    for network, reason in exemptions.items():
+        if ip in network:
+            return reason
+    return None
+
+def fetch_IPQS_score(
+    ip_addr: typing.Union[ipaddress.IPv4Address, ipaddress.IPv6Address],
+    key: str,
+    allow_public_access_points: bool = True,
+    strictness: int = 1,
+    fast: bool = False,
+    mobile: bool = False
+    ) -> tuple[float, bool, bool]: #score, is proxy, has recent abuse flag set
+    '''Perform lookup on a specific IP adress using ipqualityscore.com'''
+    params = urllib.parse.urlencode({
+        # Case to lower + handle None and other garbage
+        'allow_public_access_points': "true" if allow_public_access_points else "false",
+        'strictness': int(strictness),
+        'fast': "true" if fast else "false",
+        'mobile': "true" if mobile else "false",
+        })
+    # ip_addr sourced from server, not user, so sanitization already done
+    with urllib.request.urlopen(
+        f"https://ipqualityscore.com/api/json/ip/{key}/{str(ip_addr)}?{params}") as url:
+        data = json.loads(url.read().decode())
+        LOGGER.info(data)
+    if not data['success']:
+        errstr = f"{ip_addr} lookup failed with {data['message']}"
+        LOGGER.error(errstr)
+        raise RuntimeError(errstr)
+    return (data['score'], data["proxy"], data["recent_abuse"])
+
+def get_ip_score_from_db(session, ip):
+    query_result = session.query(KnownIPs)\
+        .filter(KnownIPs.ip == str(ip))\
+        .one_or_none()
+    if query_result:
+        #Any known problematic provider should've been BADMAILed by now, but...
+        return (query_result.score,
+                query_result.flag_recent_abuse,
+                query_result.flag_proxy
+                )
+
+def store_ip_score_in_db(session, ip, nick, IPQSresult):
+    new_known_ip = KnownEmails(ip= ip,
+                               score= IPQSresult[0],
+                               flag_recent_abuse= IPQSresult[1],
+                               flag_is_proxy= IPQSresult[2])
+    session.add(new_known_ip)
+    session.commit()
+
+def retrieve_score(bot, ip, nick, do_fetch = True):
+    session = bot.db.ssession()
+    try:
+        if retval := get_ip_score_from_db(session, ip):
+            return retval
+        elif do_fetch:
+            if IPQSresult := fetch_IPQS_ip_score(ip, config.emailcheck.IPQS_key):
+                store_ip_score_in_db(session, ip, nick, IPQSresult)
+                return IPQSresult
+            else: #Shouldn't be possible
+                raise RuntimeError("Couldn't retrieve IPQS!")
+        else:
+            # If do_fetch is false, this is a best-effort request and shouldn't use up a query
+            return None
+    except SQLAlchemyError:
+        session.rollback()
+        raise
+    finally:
+        session.remove()
+
+def _add_exemption(ip, reason):
+    exemptions[ipaddress.ip_network(ip)] = reason
 
 def _decompress(source, target, delete_after_decompression=True):
     """Decompress just the database from the archive"""
@@ -112,80 +287,246 @@ def _find_geoip_db(bot):
     else:
         return False
 
+def populate_user(bot, user, ip, host, nick):
+    LOGGER.debug('Adding: %s!%s@%s with IP %s', nick, user, host, ip)
 
-@commands('iplookup', 'ip')
-@example('.ip 8.8.8.8',
+    user = bot.users.get(nick) or target.User(nick, user, host)
+    if ip:
+        user.ip = ip # Add nonstandard field
+    bot.users[nick] = user # no-op if user was in users, needed otherwise
+
+def examine_user(bot, user, ip, host, nick):
+    populate_user(bot, user, ip, host, nick)
+    res = retrieve_score(bot, ip, nick)
+    if res:
+        score, is_proxy, is_recent_abuse = res
+        if( is_prox or is_recent_abuse or score >= config.ip.malicious_threshold ):
+            alert(bot, f"Ops: Nick {nick} has abuse score {score}, proxy: {is_prox}, "
+                        "recent_abuse: {is_recent_abuse}; z-lining!")
+            bot.write("ZLINE", ip, "24h", f":Auto z-line {nick}.")
+            protect_chans(bot)
+        elif score >= config.ip.warn_threshold:
+            alert(bot, f"Ops: Nick {nick} has abuse score {score}; keep an eye on them.")
+    return res
+
+@module.event(events.RPL_WHOSPCRPL)
+@module.priority('high')
+def recv_whox_ip(bot, trigger):
+    """Track ``WHO`` responses when ``WHOX`` is enabled."""
+    #LOGGER.debug('Receiving who: %s', trigger.args[1])
+    if len(trigger.args) < 2 or trigger.args[1] not in who_reqs:
+        # Ignored, some other plugin probably called WHO
+        return
+    #it's us
+    # :safe.oh.us.irc.scpwiki.com 354 Kufat 0 kufat 2001:470:1f07:13b::1 gatekeeper.kufat.net :Kufat
+    if len(trigger.args) != 6:
+        return LOGGER.warning('While populating the IP DB, a WHO response was malformed.')
+    _, _, user, ip, host, nick = trigger.args
+    examine_user(bot, user, ip, host, nick)
+
+@module.event(events.RPL_ENDOFWHO)
+@module.priority('high')
+def end_who_ip(bot, trigger):
+    """Handle the end of a response to a ``WHO`` command (if needed)."""
+    if 'WHOX' in bot.isupport:
+        who_reqs.pop(trigger.args[1], None)
+
+@module.event(events.RPL_YOUREOPER)
+@module.priority('high')
+def send_who(bot, _):
+    if 'WHOX' in bot.isupport:
+        # WHOX syntax, see http://faerion.sourceforge.net/doc/irc/whox.var
+        # Needed for accounts in WHO replies. The random integer is a param
+        # to identify the reply as one from this command, because if someone
+        # else sent it, we have no way to know what the format is.
+
+        # 'x' indicates uncloaked address. This is triggered by
+        # RPL_YOUREOPER because that functionality is restricted to opers.
+        rand = str(randint(0, 999))
+        while rand in who_reqs:
+            rand = str(randint(0, 999))
+        LOGGER.debug('Sending who: %s', rand)
+        who_reqs[rand] = True
+        bot.write([r'WHO * n%nuhti,' + rand])
+
+#:safe.oh.us.irc.scpwiki.com NOTICE Kufat :*** CONNECT: Client connecting on port 6697 (class main): ASNbot!sopel@ool-45734b07.dyn.optonline.net (69.115.75.7) [Sopel: https://sopel.chat/]
+@module.rule(r'.*Client connecting .*: (\S*)!(\S*)@(\S*) \((.*)\)')
+@module.event("NOTICE")
+@module.priority("high")
+def handle_snotice_conn(bot, trigger):
+    LOGGER.debug("Saw connect line: [%s] from [%s]", trigger.raw, trigger.sender)
+    #Only servers may have '.' in the sender name, so this isn't spoofable
+    if "scpwiki.com" in trigger.sender:
+        nick, user, host, ip = trigger.groups()
+        examine_user(bot, user, ip, None, nick) #cloaked host not known
+        #Be **certain** we don't waste our lookups on irccloud
+        if any(host.endswith(s) for s in (".irccloud.com", ".mibbit.com")):
+            return
+        # We need to check if the IP is in any exempt CIDR ranges
+        if get_exemption(ip):
+            return
+
+        res = examine_user(bot, user, ip, host, nick)
+        if res:
+            # Acted on above; just log here
+            score, is_proxy, is_recent_abuse = res
+            LOGGER.debug(f"handle_snotice_conn: {nick}!{user}@{host} ({ip}) had "
+                          "score {score}, proxy: {is_prox}, "
+                          "recent_abuse: {is_recent_abuse}")
+
+# NICK: User Kufat-bar changed their nickname to Kufat-foo
+# This is redundant for users the bot can see in-channel but needed for users with no common channel
+@module.rule(r'.*User (\S+) changed their nickname to (\S+).*')
+@module.event("NOTICE")
+@module.priority("high")
+def handle_snotice_ren(bot, trigger):
+    LOGGER.debug("Saw nick change line: [%s] from [%s]", trigger.raw, trigger.sender)
+    if "scpwiki.com" in trigger.sender:
+        oldnick = Identifier(trigger.group(1))
+        newnick = Identifier(trigger.group(2))
+        if olduser := bot.users.get(oldnick):
+            populate_user(bot, olduser.user, olduser.ip, olduser.host, newnick)
+
+@module.require_privilege(module.OP)
+@module.commands('ip_exempt')
+@module.example('.ip_exempt 8.8.8.8')
+def ip_exempt(bot, trigger):
+    if not trigger.group(3):
+        return bot.reply("You must specify an IP or range in CIDR format to exempt.")
+    elif not trigger.group(4):
+        return bot.reply("You must specify a reason for the exemption.")
+    ipstr = trigger.group(3)
+    if '*' in ipstr:
+        return bot.reply("Use CIDR format (1.2.3.0/24) rather than wildcard format (1.2.3.*)")
+    reason = trigger.group(2).lstrip(ipstr).lstrip()
+    try:
+        _add_exemption(ipstr, reason)
+    except ValueError as e:
+        return bot.reply(f"Could not add exemption for {ipstr} because: {str(e)}")
+
+@module.require_privilege(module.HALFOP)
+@module.commands('iplookup', 'ip')
+@module.example('.ip 8.8.8.8',
          r'\[IP\/Host Lookup\] Hostname: \S*dns\S*\.google\S*( \| .+?: .+?)+ \| ISP: AS15169 \S+',
          re=True,
          ignore='Downloading GeoIP database, please wait...',
          online=True)
 def ip(bot, trigger):
+    if trigger.is_privmsg and ( trigger.account is None or trigger.account.lower() != "kufat" ):
+        return
+    full = ( ( trigger.sender.lower() in ("#skipirc-staff", "#kufat") ) or
+    ( trigger.is_privmsg and trigger.account.lower() == "kufat" ) )
+    irccloud = False
+    mibbit = False
+    nick = None
     """IP Lookup tool"""
     # Check if there is input at all
     if not trigger.group(2):
-        return bot.reply("No search term.")
+        return bot.reply("Usage: '.ip (Nick or address) [lookup]'. "
+                         "If 'lookup' is specified, will look up IP score if not known.")
     # Check whether the input is an IP or hostmask or a nickname
+    search_str = trigger.group(3) # Groups 3-6 = command args 1-4
     decide = ['.', ':']
-    if any(x in trigger.group(2) for x in decide):
+    if any(x in search_str for x in decide):
         # It's an IP/hostname!
-        query = trigger.group(2).strip()
+        query = search_str.strip()
     else:
-        # Need to get the host for the username
-        username = trigger.group(2).strip()
-        user_in_botdb = bot.users.get(username)
-        if user_in_botdb is not None:
-            query = user_in_botdb.host
-
-            # Sanity check - sometimes user information isn't populated yet
-            if query is None:
-                return bot.say("I don't know that user's host.")
+        # Need to get the ip for the username
+        nick = search_str.strip().lower()
+        if user_in_botdb := bot.users.get(nick):
+            if hasattr(user_in_botdb, "ip") and user_in_botdb.ip:
+                query = user_in_botdb.ip
+                # Sanity check - sometimes user information isn't populated yet
+            else:
+                return bot.say("I don't know that user's IP.")
         else:
+            #TODO TODO TODO get from DB
             return bot.say("I\'m not aware of this user.")
 
-    db_path = _find_geoip_db(bot)
-    if db_path is False:
-        LOGGER.error('Can\'t find (or download) usable GeoIP database.')
-        bot.say('Sorry, I don\'t have a GeoIP database to use for this lookup.')
-        return False
+    ex = get_exemption(query).lower()
 
-    if ':' in query:
-        try:
-            socket.inet_pton(socket.AF_INET6, query)
-        except (OSError, socket.error):  # Python 2/3 compatibility
-            return bot.say("[IP/Host Lookup] Unable to resolve IP/Hostname")
-    elif '.' in query:
-        try:
-            socket.inet_pton(socket.AF_INET, query)
-        except (socket.error, socket.herror):
+    if ex:
+        irccloud = "irccloud" in ex
+        mibbit = "mibbit" in ex
+    if not any((irccloud, mibbit)):
+        db_path = _find_geoip_db(bot)
+        if db_path is False:
+            LOGGER.error('Can\'t find (or download) usable GeoIP database.')
+            bot.say('Sorry, I don\'t have a GeoIP database to use for this lookup.')
+            return False
+
+        if ':' in query:
             try:
-                query = socket.getaddrinfo(query, None)[0][4][0]
-            except socket.gaierror:
+                socket.inet_pton(socket.AF_INET6, query)
+            except (OSError, socket.error):  # Python 2/3 compatibility
                 return bot.say("[IP/Host Lookup] Unable to resolve IP/Hostname")
+        elif '.' in query:
+            try:
+                socket.inet_pton(socket.AF_INET, query)
+            except (socket.error, socket.herror):
+                try:
+                    query = socket.getaddrinfo(query, None)[0][4][0]
+                except socket.gaierror:
+                    return bot.say("[IP/Host Lookup] Unable to resolve IP/Hostname")
+        else:
+            return bot.say("[IP/Host Lookup] Unable to resolve IP/Hostname")
+
+        city = geoip2.database.Reader(os.path.join(db_path, 'GeoLite2-City.mmdb'))
+        asn = geoip2.database.Reader(os.path.join(db_path, 'GeoLite2-ASN.mmdb'))
+        host = socket.getfqdn(query)
+        try:
+            city_response = city.city(query)
+            asn_response = asn.asn(query)
+        except geoip2.errors.AddressNotFoundError:
+            return bot.say("[IP/Host Lookup] The address is not in the database.")
+
+    response = "[IP/Host Lookup]"
+
+    if irccloud:
+        response += " IP belongs to IRCCloud; no location data available"
+        return bot.say(response)
+    elif mibbit:
+        response += " IP belongs to mibbit; no location data available"
+        return bot.say(response)
     else:
-        return bot.say("[IP/Host Lookup] Unable to resolve IP/Hostname")
+        response += f" | IP meets exemption [{ex}] |"
+        # Still look up an IP that's exempt for other reasons
 
-    city = geoip2.database.Reader(os.path.join(db_path, 'GeoLite2-City.mmdb'))
-    asn = geoip2.database.Reader(os.path.join(db_path, 'GeoLite2-ASN.mmdb'))
-    host = socket.getfqdn(query)
-    try:
-        city_response = city.city(query)
-        asn_response = asn.asn(query)
-    except geoip2.errors.AddressNotFoundError:
-        return bot.say("[IP/Host Lookup] The address is not in the database.")
+    if full:
+        response += " Hostname: %s |" % host
 
-    response = "[IP/Host Lookup] Hostname: %s" % host
     try:
-        response += " | Location: %s" % city_response.country.name
+        response_loc = " Location: %s" % city_response.country.name
+        region = city_response.subdivisions.most_specific.name
+        response_loc += " | Region: %s" % region if region else ""
+
+        if full:
+            city = city_response.city.name
+            response_loc += " | City: %s" % city if city else ""
+
+        response += response_loc
+
     except AttributeError:
-        response += ' | Location: Unknown'
+        response += ' Location: Unknown'
 
-    region = city_response.subdivisions.most_specific.name
-    response += " | Region: %s" % region if region else ""
-    city = city_response.city.name
-    response += " | City: %s" % city if city else ""
-    isp = "AS" + str(asn_response.autonomous_system_number) + \
-          " " + asn_response.autonomous_system_organization
-    response += " | ISP: %s" % isp if isp else ""
+    try:
+        isp = "AS" + str(asn_response.autonomous_system_number) + \
+            " " + asn_response.autonomous_system_organization
+        response += " | ISP: %s" % isp if isp else ""
+    except:
+        response += ' ISP: Unknown'
+
+    force_lookup = trigger.group(4) == "lookup"
+    res = None
+    try:
+        res = retrieve_score(bot, query, nick, force_lookup)
+    except Exception as e:
+        LOGGER.error(f"Couldn't look up IP {query} because {e}")
+    if res:
+        response += f" | Score: {res[0]} Proxy: {res[1]} Recent abuse detected: {res[2]}"
+    elif not force_lookup:
+        # Use search_str to avoid leaking an IP
+        response += f" | To retrieve IP score run '.ip {search_str} lookup'"
     bot.say(response)
 
 

--- a/sopel/modules/ip.py
+++ b/sopel/modules/ip.py
@@ -389,15 +389,16 @@ def handle_snotice_ren(bot, trigger):
 
 @module.require_privilege(module.OP)
 @module.commands('ip_exempt')
-@module.example('.ip_exempt 8.8.8.8')
+@module.example('.ip_exempt 8.8.8.8 Known user example123\'s bouncer')
 def ip_exempt(bot, trigger):
-    if not trigger.group(3):
+    if not ipstr := trigger.group(3): # arg 1
         return bot.reply("You must specify an IP or range in CIDR format to exempt.")
-    elif not trigger.group(4):
+    elif not trigger.group(4): # arg 2 must exist; need at least one word of desc
         return bot.reply("You must specify a reason for the exemption.")
-    ipstr = trigger.group(3)
     if '*' in ipstr:
         return bot.reply("Use CIDR format (1.2.3.0/24) rather than wildcard format (1.2.3.*)")
+    # Desc may be multiple words. Group 2 is all arguments. Strip off the first one and
+    # keep the rest. Based on code from the tell.py module.
     reason = trigger.group(2).lstrip(ipstr).lstrip()
     try:
         _add_exemption(ipstr, reason)

--- a/sopel/modules/ip.py
+++ b/sopel/modules/ip.py
@@ -173,9 +173,9 @@ def fetch_IPQS_score(
     ) -> tuple[float, bool, bool]: #score, is proxy, has recent abuse flag set
     '''Perform lookup on a specific IP adress using ipqualityscore.com'''
     params = urllib.parse.urlencode({
-        # Case to lower + handle None and other garbage
         'allow_public_access_points': "true" if allow_public_access_points else "false",
         'strictness': int(strictness),
+        # lowercase + handle None and other non-bool garbage
         'fast': "true" if fast else "false",
         'mobile': "true" if mobile else "false",
         })


### PR DESCRIPTION
I had to rush this along when my original prototype IP scoring bot (which was a very, very preliminary version of this) dies because of a WSL hiccup and I was unable to restart it. It has all the basic features I wanted for both IP and email checking, mainly scoring and a persistent database so we don't waste queries (5k/mo quota.)

Haven't tested this yet, although I did make sure it parsed and loaded on a sopel instance that wasn't connected to anything.